### PR TITLE
DRAFT: remove lazy_static dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,6 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "include_directory",
- "lazy_static",
  "log",
  "migration",
  "notify-debouncer-full",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ deno_core = "0.191.0"
 env_logger = { git = "https://github.com/tmccombs/env_logger", rev = "a47d1d99", features=["kv_unstable"] }
 futures-channel = "0.3.26"
 futures-util = "0.3.26"
-lazy_static = "1.4.0"
 log = { version = "0.4.17", features = ["kv_unstable", "kv_unstable_serde"] }
 prost = "0.11.8"
 prost-types = "0.11.8"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/deno_extension/cmd.rs
+++ b/src/deno_extension/cmd.rs
@@ -5,7 +5,7 @@ use std::{
     io::{Error, ErrorKind},
     pin::Pin,
     process::Stdio,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     task::{Context, Poll},
 };
 
@@ -19,19 +19,12 @@ use tokio::{
 
 use deno_core::{error::AnyError, op, OpDecl};
 
-use lazy_static::lazy_static;
-
 use crate::JsMessage;
 
-lazy_static! {
-    static ref MAX_SESSION: Arc<Mutex<i32>> = Arc::new(Mutex::new(0));
-}
-
-lazy_static! {
-    static ref CMD_CANCELLATION_MAP: RwLock<HashMap<u32, AbortHandle>> =
-        RwLock::new(HashMap::new());
-    static ref CMD_SESSION_MAP: RwLock<HashMap<u32, Vec<i32>>> = RwLock::new(HashMap::new());
-}
+static CMD_CANCELLATION_MAP: LazyLock<RwLock<HashMap<u32, AbortHandle>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+static CMD_SESSION_MAP: LazyLock<RwLock<HashMap<u32, Vec<i32>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 struct CmdWriter {
     channel: i32,

--- a/src/deno_extension/fs_events.rs
+++ b/src/deno_extension/fs_events.rs
@@ -9,17 +9,22 @@ use serde::Serialize;
 
 use deno_core::error::AnyError;
 
-use lazy_static::lazy_static;
-use std::{collections::HashMap, io::Error, path::Path, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    io::Error,
+    path::Path,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 use tokio::sync::{Mutex, RwLock};
 
-lazy_static! {
-    static ref FILE_WATCHER_MAP: Arc<RwLock<HashMap<u32, Arc<Mutex<Debouncer<RecommendedWatcher, FileIdMap>>>>>> =
-        Arc::new(RwLock::new(HashMap::new()));
-    static ref FILE_WATCHER_MESSAGES: Arc<RwLock<HashMap<u32, Arc<deadqueue::unlimited::Queue<FinalEvent>>>>> =
-        Arc::new(RwLock::new(HashMap::new()));
-    static ref MAX_WATCHER: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
-}
+static FILE_WATCHER_MAP: LazyLock<
+    RwLock<HashMap<u32, Arc<Mutex<Debouncer<RecommendedWatcher, FileIdMap>>>>>,
+> = LazyLock::new(|| RwLock::new(HashMap::new()));
+static FILE_WATCHER_MESSAGES: LazyLock<
+    RwLock<HashMap<u32, Arc<deadqueue::unlimited::Queue<FinalEvent>>>>,
+> = LazyLock::new(|| RwLock::new(HashMap::new()));
+static MAX_WATCHER: LazyLock<Mutex<u32>> = LazyLock::new(|| Mutex::new(0));
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/deno_extension/pty.rs
+++ b/src/deno_extension/pty.rs
@@ -4,7 +4,7 @@ use portable_pty::PtySize;
 use std::{
     collections::{HashMap, VecDeque},
     io::{Error, ErrorKind, Write},
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use crate::channels::IPCMessage;
@@ -13,19 +13,12 @@ use tokio::sync::{Mutex, RwLock};
 
 use deno_core::{error::AnyError, op, OpDecl};
 
-use lazy_static::lazy_static;
-
 use crate::JsMessage;
 
-lazy_static! {
-    static ref MAX_SESSION: Arc<Mutex<i32>> = Arc::new(Mutex::new(0));
-}
-
-lazy_static! {
-    static ref PTY_CANCELLATION_MAP: RwLock<HashMap<u32, AbortHandle>> =
-        RwLock::new(HashMap::new());
-    static ref PTY_SESSION_MAP: RwLock<HashMap<u32, Vec<i32>>> = RwLock::new(HashMap::new());
-}
+static PTY_CANCELLATION_MAP: LazyLock<RwLock<HashMap<u32, AbortHandle>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+static PTY_SESSION_MAP: LazyLock<RwLock<HashMap<u32, Vec<i32>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 struct PtyWriter {
     channel: i32,


### PR DESCRIPTION
closes #21 

Currently requires that we switch to nightly as [std::sync::LazyLock](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) is not stabilized yet, see https://github.com/rust-lang/rust/issues/109736.